### PR TITLE
Reuse cached camera streams across camera dialogs

### DIFF
--- a/src/lib/camera-permission.ts
+++ b/src/lib/camera-permission.ts
@@ -1,0 +1,40 @@
+type CameraPermissionState = {
+    granted: boolean;
+    stream: MediaStream | null;
+};
+
+const state: CameraPermissionState = {
+    granted: false,
+    stream: null
+};
+
+const replaceCachedStream = (stream: MediaStream | null) => {
+    if (state.stream && state.stream !== stream) {
+        state.stream.getTracks().forEach((track) => track.stop());
+    }
+    state.stream = stream;
+};
+
+export function hasCameraPermissionGranted(): boolean {
+    return state.granted;
+}
+
+export function setCameraPermissionGranted(stream?: MediaStream | null) {
+    state.granted = true;
+    if (stream !== undefined) {
+        replaceCachedStream(stream);
+    }
+}
+
+export function resetCameraPermission() {
+    state.granted = false;
+    if (state.stream) {
+        replaceCachedStream(null);
+    }
+}
+
+export function consumeCachedCameraStream(): MediaStream | null {
+    const stream = state.stream;
+    state.stream = null;
+    return stream;
+}


### PR DESCRIPTION
## Summary
- refine the camera-permission helper to manage cached stream lifecycle safely while preserving reuse behaviour
- reuse a cached stream before calling getUserMedia in both camera capture components
- ensure permission resets on NotAllowedError while updating helpers with the active stream

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2244df16083269b6eae9ea9a40b40